### PR TITLE
:pencil: 更新友链地址

### DIFF
--- a/src/links.yml
+++ b/src/links.yml
@@ -64,8 +64,8 @@
   blog: 皮皮凛の小窝
   desc: 永远相信美好的事情即将发生~
   color: hotpink
-- url: https://royce2003.top
-  avatar: https://cdn.jsdelivr.net/gh/Royce2019/img/img/avatar.jpg
+- url: https://www.royce2003.top
+  avatar: https://cdn.jsdelivr.net/gh/Royce2019/BlogSource/about/Royce.webp
   name: Royce
   blog: Royce 的小窝
   desc: OI 小白


### PR DESCRIPTION
原链接可能因为防盗链无法跳转，但是直接访问没问题的