### PR TITLE
`blog.nin.red` migrated to `nin.red`

### DIFF
--- a/public/links.yml
+++ b/public/links.yml
@@ -360,13 +360,13 @@
   desc: 花有重开日，人无再少年。
   email: imcao@imcao.cn
   color: "#49b1f5"
-- url: https://blog.nin.red
-  avatar: https://blog.nin.red/img/icon.png
+- url: https://nin.red
+  avatar: https://nin.red/static/blog-icon.png
   name: NoahHrreion
-  blog: NBlog
-  desc: 由一条咸鱼搭建的博客
+  blog: Nriot's Website
+  desc: 由一条咸鱼搭建的网站
   email: nriot233@outlook.com
-  color: "#46c48b"
+  color: "#0b9c6e"
 - url: https://blog.sxzz.moe/
   avatar: https://fastly.jsdelivr.net/gh/sxzz/static@latest/avatar.png
   name: 三咲智子


### PR DESCRIPTION
[blog.nin.red](https://blog.nin.red)的所有内容现已全部迁移至[nin.red](https://nin.red)，希望更新一下友链，谢谢！