### PR TITLE
😺 www.miaoer.net

### DIFF
--- a/public/links.yml
+++ b/public/links.yml
@@ -346,8 +346,8 @@
   desc: 两岸猿声啼不住 轻舟已过万重山
   email: YuZhangWang233@163.com
   color: "#7FC8F8"
-- url: https://www.miaoer.xyz
-  avatar: https://www.miaoer.xyz/weblogo.jpg
+- url: https://www.miaoer.net
+  avatar: https://static.miaoer.net/logo/avatar.webp
   name: 喵二
   blog: 喵二の小博客
   desc: 缘，妙不可言


### PR DESCRIPTION
因为 .xyz 不易被国内搜索引擎收入，所更换域名为 .net

原始：miaoer.xyz -> miaoer.net